### PR TITLE
Removes ymax from average.tex to fix overflow

### DIFF
--- a/tex/average.tex
+++ b/tex/average.tex
@@ -53,7 +53,6 @@
 	width=22cm,
 	height=7cm,
 	ymin=0,
-	ymax=1250,
 	xmin={10:30},
 	xmax={15:30},
 	xtick={11:00.1, 12:00, 13:00.1, 14:00, 15:00.1}, % apparently there's something wrong with rounding or floats in the coord trafo above


### PR DESCRIPTION
Currently, the max. number of people often reaches beyond 1250. Removing the ymax means that PGFplots will automatically choose a fitting value.

Before:
![image](https://user-images.githubusercontent.com/5780401/233993833-2437222d-cbd3-4c21-b196-44052fc9211b.png)

After:
![image](https://user-images.githubusercontent.com/5780401/233993849-886e4945-394a-40d3-82a5-c3ced15c2e4f.png)
